### PR TITLE
SCRUM-120: Fix POSTGRES_DB_TESTING inline comment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,8 @@ POSTGRES_PASSWORD=postgres
 SERVICE_PORT_EXT=8000
 
 # Testing
-POSTGRES_DB_TESTING=app_test # Always use the POSTGRES_DB name with _test
+# Always use the POSTGRES_DB name with _test
+POSTGRES_DB_TESTING=app_test
 
 # Items Service
 ITEMS_SERVICE_PORT=

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -22,6 +22,7 @@ class Settings(BaseSettings):
     POSTGRES_USER: str
     POSTGRES_PASSWORD: str
     POSTGRES_DB: str
+    POSTGRES_DB_TESTING: str
     API_KEY: str
 
     # Services
@@ -52,7 +53,7 @@ class TestSettings(Settings):
             password=self.POSTGRES_PASSWORD,
             host=self.POSTGRES_SERVER,
             port=self.POSTGRES_PORT_EXT,
-            path=self.POSTGRES_DB + "_test",
+            path=self.POSTGRES_DB_TESTING,
         )
 
 


### PR DESCRIPTION
- Move POSTGRES_DB_TESTING environment variable inline comment in .env.example
- Update the TestingSetting, in config.py, for using POSTGRES_DB_TESTING environment variable instead of POSTGRES_DB variable combined with the “_test” hardcode