### PR TITLE
SCRUM-263: telegram id to big integer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ app.egg-info
 .git
 .pytest_cache
 *.xml
+.idea

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -2,6 +2,7 @@ import re
 import uuid
 
 from pydantic import field_validator
+from sqlalchemy import BigInteger
 from sqlmodel import Field, Index, SQLModel
 
 from app.utilities.exceptions import InvalidEmailHttpException
@@ -14,7 +15,7 @@ class UserBase(SQLModel):
     name: str = Field(min_length=1, max_length=255)
     email: str = Field(unique=True)
     phone: str = Field(unique=True)
-    telegram_id: int | None = Field(default=None)
+    telegram_id: int | None = Field(default=None, sa_type=BigInteger)
 
     @field_validator("email", mode="before")
     def validate_email(cls, value):

--- a/app/tests/models/test_user.py
+++ b/app/tests/models/test_user.py
@@ -16,6 +16,22 @@ async def test_create_user_with_multiple_extension_on_email() -> None:
     assert user.phone == user_phone
 
 
+async def test_create_user_may_contain_telegram_id_as_big_integer() -> None:
+    user_name = "Robert"
+    user_email = "abbondanzieri@yahoo.com.ar"
+    user_phone = "11 1234 5678"
+    telegram_id = 5000400300
+
+    user = UserCreate(
+        name=user_name, email=user_email, phone=user_phone, telegram_id=telegram_id
+    )
+
+    assert user.name == user_name
+    assert user.email == user_email
+    assert user.phone == user_phone
+    assert user.telegram_id == telegram_id
+
+
 async def test_create_user_name_min_size_is_1() -> None:
     with pytest.raises(ValueError):
         name = ""


### PR DESCRIPTION
- `telegram_id` for `UserBase` was changed for supponrt numbers more than range of int (> 3.000.000.000)