### PR TITLE
SCRUM-306: Fix remove telegram_id from payload of create_player on player service

### DIFF
--- a/app/services/players_service.py
+++ b/app/services/players_service.py
@@ -16,11 +16,9 @@ class PlayersService(BaseService):
         )
         self.set_base_headers({"x-api-key": settings.PLAYERS_SERVICE_API_KEY})
 
-    async def create_player(self, user_public_id: UUID, telegram_id: int | None) -> Any:
+    async def create_player(self, user_public_id: UUID) -> Any:
         """Create player using players service."""
         payload = {"user_public_id": str(user_public_id)}
-        if telegram_id:
-            payload["telegram_id"] = int(telegram_id)
         return await self.post(
             "/api/v1/players/",
             json=payload,

--- a/app/services/users_service.py
+++ b/app/services/users_service.py
@@ -22,7 +22,6 @@ class UsersService:
                 await session.refresh(password)
             await PlayersService().create_player(
                 user_public_id=user_dict.get("public_id"),
-                telegram_id=user_dict.get("telegram_id"),
             )
             await session.refresh(user)
             return user

--- a/app/tests/utils/users.py
+++ b/app/tests/utils/users.py
@@ -1,9 +1,9 @@
 from app.utilities.exceptions import ExternalServiceException
 
 
-async def mock_call_player_create(_self, user_public_id, telegram_id):  # noqa: ARG001
+async def mock_call_player_create(_self, user_public_id):  # noqa: ARG001
     return None
 
 
-async def mock_call_player_create_raise_exception(_self, user_public_id, telegram_id):  # noqa: ARG001
+async def mock_call_player_create_raise_exception(_self, user_public_id):  # noqa: ARG001
     raise ExternalServiceException("external-service", "error")


### PR DESCRIPTION
- remove `telegram_id` from payload on create_user